### PR TITLE
feat: #17: Edit the configuration as auto-configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ class RepoTest {
 }
 ```
 
+You also have the possibility to define the `DataSource` you want to proxy by defining a property in the configuration 
+file with the property `datasource.name` and the `ProfilerAutoConfiguration` class will handle how to create the proxy bean to monitor.
+
+By this way a project with multiple `DataSource` can still be tested by choosing the bean to monitor.
+
 It's possible that you hit the following error: 
 
 ```

--- a/hibernate-profiler-spring/pom.xml
+++ b/hibernate-profiler-spring/pom.xml
@@ -50,6 +50,22 @@
             <groupId>org.hibernate.orm</groupId>
             <artifactId>hibernate-core</artifactId>
         </dependency>
+
+        <!-- test dependencies -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-test</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/hibernate-profiler-spring/src/main/java/org/maequise/hibernate/profiler/configuration/DataSourceCondition.java
+++ b/hibernate-profiler-spring/src/main/java/org/maequise/hibernate/profiler/configuration/DataSourceCondition.java
@@ -1,0 +1,12 @@
+package org.maequise.hibernate.profiler.configuration;
+
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+
+class DataSourceCondition implements Condition {
+    @Override
+    public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+        return context.getEnvironment().getProperty("datasource.name") == null;
+    }
+}

--- a/hibernate-profiler-spring/src/main/java/org/maequise/hibernate/profiler/configuration/ProfilerAutoConfiguration.java
+++ b/hibernate-profiler-spring/src/main/java/org/maequise/hibernate/profiler/configuration/ProfilerAutoConfiguration.java
@@ -7,19 +7,44 @@ import net.ttddyy.dsproxy.support.ProxyDataSourceBuilder;
 import org.hibernate.engine.jdbc.internal.FormatStyle;
 import org.hibernate.engine.jdbc.internal.Formatter;
 import org.maequise.hibernate.profiler.listeners.Listener;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.AutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Conditional;
 import org.springframework.context.annotation.Primary;
 import org.springframework.core.annotation.Order;
 
 import javax.sql.DataSource;
 
-@Configuration
+@AutoConfiguration
 @Order
-public class ProfilerConfiguration {
+@ConditionalOnBean(DataSource.class)
+public class ProfilerAutoConfiguration {
     @Bean
     @Primary
+    @Conditional(DataSourceCondition.class)
     public DataSource dataSourceProxied(DataSource dataSource) {
+        return createProxiedDataSource(dataSource);
+    }
+
+    @Bean
+    @Primary
+    @ConditionalOnProperty("datasource.name")
+    public DataSource dataSourceNamed(AnnotationConfigApplicationContext context,
+                                      @Value("${datasource.name}") String name) {
+        DataSource namedBean = context.getBean(name, DataSource.class);
+
+        var p = createProxiedDataSource(namedBean);
+
+        context.registerBean("proxied".concat(name),
+                DataSource.class, () -> p);
+        return p;
+    }
+
+    private DataSource createProxiedDataSource(DataSource ds) {
         var chainListeners = new ChainListener();
 
         PrettyQueryEntryCreator creator = new PrettyQueryEntryCreator();
@@ -32,7 +57,7 @@ public class ProfilerConfiguration {
         chainListeners.addListener(new Listener());
 
         return ProxyDataSourceBuilder
-                .create(dataSource)
+                .create(ds)
                 .name("dataSource")
                 .listener(chainListeners)
                 .build();

--- a/hibernate-profiler-spring/src/test/java/org/maequise/hibernate/profiler/configuration/ProfilerAutoConfigurationTest.java
+++ b/hibernate-profiler-spring/src/test/java/org/maequise/hibernate/profiler/configuration/ProfilerAutoConfigurationTest.java
@@ -1,0 +1,93 @@
+package org.maequise.hibernate.profiler.configuration;
+
+import net.ttddyy.dsproxy.support.ProxyDataSource;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.boot.test.context.runner.ApplicationContextRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Conditional;
+
+import javax.sql.DataSource;
+
+class ProfilerAutoConfigurationTest {
+    ApplicationContextRunner contextRunner;
+
+    @BeforeEach
+    void setup() {
+        contextRunner = new ApplicationContextRunner()
+                .withConfiguration(AutoConfigurations.of(ProfilerAutoConfiguration.class));
+    }
+
+    @Test
+    @DisplayName("Test auto configuration with no provided datasource provided")
+    void test_auto_configuration_no_datasource_provided() {
+        this.contextRunner
+                .run(context -> {
+            Assertions.assertThat(context).doesNotHaveBean(DataSource.class);
+        });
+    }
+
+    @Test
+    @DisplayName("")
+    void test_auto_configuration_datasource_provided() {
+        this.contextRunner
+                .withUserConfiguration(MockDataSourceConfiguration.class)
+                .run(context -> {
+                    Assertions.assertThat(context).hasBean("dataSource");
+                    Assertions.assertThat(context).hasBean("dataSourceProxied");
+                });
+    }
+
+    @Test
+    @DisplayName("")
+    void test_auto_configuration_datasource_property() {
+        this.contextRunner
+                .withUserConfiguration(MockDataSourceConfiguration.class)
+                .withPropertyValues("datasource.name=test")
+                .run(context -> {
+                    Assertions.assertThat(context).hasBean("test");
+                    Assertions.assertThat(context).hasBean("proxiedtest");
+                    Assertions.assertThat(context).doesNotHaveBean("testBis");
+                });
+    }
+
+    @Test
+    @DisplayName("")
+    void test_auto_configuration_datasource_property_ds_bis() {
+        this.contextRunner
+                .withUserConfiguration(MockDataSourceConfiguration.class)
+                .withPropertyValues("datasource.name=testBis")
+                .run(context -> {
+                    Assertions.assertThat(context).hasBean("test");
+                    Assertions.assertThat(context).hasBean("testBis");
+                    Assertions.assertThat(context).hasBean("proxiedtestBis");
+                });
+    }
+
+    @TestConfiguration
+    static class MockDataSourceConfiguration {
+        @Bean
+        @Conditional(DataSourceCondition.class)
+        DataSource dataSource() {
+            return new ProxyDataSource();
+        }
+
+        @Bean
+        @ConditionalOnProperty("datasource.name")
+        DataSource test() {
+            return new ProxyDataSource();
+        }
+
+        @Bean
+        @ConditionalOnProperty(value = "datasource.name", havingValue = "testBis")
+        DataSource testBis() {
+            return new ProxyDataSource();
+        }
+    }
+
+}

--- a/hibernate-profiler-tests/src/test/java/org/maequise/hibernate/profiler/tests/DatabaseConfiguration.java
+++ b/hibernate-profiler-tests/src/test/java/org/maequise/hibernate/profiler/tests/DatabaseConfiguration.java
@@ -1,20 +1,19 @@
 package org.maequise.hibernate.profiler.tests;
 
-import org.maequise.hibernate.profiler.configuration.ProfilerConfiguration;
+import org.maequise.hibernate.profiler.configuration.ProfilerAutoConfiguration;
 import org.springframework.boot.hibernate.autoconfigure.HibernateProperties;
 import org.springframework.boot.jpa.autoconfigure.JpaProperties;
 import org.springframework.boot.persistence.autoconfigure.EntityScan;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseBuilder;
 import org.springframework.jdbc.datasource.embedded.EmbeddedDatabaseType;
 
 import javax.sql.DataSource;
 
 @TestConfiguration
-@Import(ProfilerConfiguration.class)
+@Import(ProfilerAutoConfiguration.class)
 @EntityScan("org.maequise.hibernate.profiler.tests.entities")
 
 public class DatabaseConfiguration {

--- a/pom.xml
+++ b/pom.xml
@@ -127,6 +127,19 @@
                 <scope>test</scope>
             </dependency>
 
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-test</artifactId>
+                <version>${spring.boot.version}</version>
+                <scope>provided</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>org.assertj</groupId>
+                <artifactId>assertj-core</artifactId>
+                <version>3.27.7</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
Make the possibility to define the proxied datasource with a property defining the bean to use Add tests for the auto-configuration
Create a custom condition to activate the path of bean creation Add test dependencies